### PR TITLE
Export api to transfer fee from module to account

### DIFF
--- a/x/auth/types/expected_keepers.go
+++ b/x/auth/types/expected_keepers.go
@@ -7,4 +7,5 @@ import (
 // BankKeeper defines the contract needed for supply related APIs (noalias)
 type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 }


### PR DESCRIPTION
This api is used by ante handler to refund fee from Module to account.