### PR TITLE
fix: align v0.45.11-inj release with missing v0.45.10-inj commits

### DIFF
--- a/client/tx_config.go
+++ b/client/tx_config.go
@@ -43,5 +43,6 @@ type (
 		SetGasLimit(limit uint64)
 		SetTimeoutHeight(height uint64)
 		SetFeeGranter(feeGranter sdk.AccAddress)
+		SetFeePayer(feePayer sdk.AccAddress)
 	}
 )

--- a/x/auth/legacy/legacytx/stdtx_builder.go
+++ b/x/auth/legacy/legacytx/stdtx_builder.go
@@ -19,6 +19,9 @@ type StdTxBuilder struct {
 	cdc *codec.LegacyAmino
 }
 
+// SetFeePayer does nothing for stdtx
+func (s *StdTxBuilder) SetFeePayer(_ sdk.AccAddress) {}
+
 // ensure interface implementation
 var _ client.TxBuilder = &StdTxBuilder{}
 


### PR DESCRIPTION
This PR simply inject v0.45.10-inj missing commits in  v0.45.11-inj code base.