### PR TITLE
feat: add marker event to detect cosmos 47 upgrade

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -196,8 +196,13 @@ func (app *BaseApp) BeginBlock(req abci.RequestBeginBlock) (res abci.ResponseBeg
 		res = app.beginBlocker(app.deliverState.ctx, req)
 		res.Events = sdk.MarkEventsToIndex(res.Events, app.indexEvents)
 	}
+
 	// set the signed validators for addition to context in deliverTx
 	app.voteInfos = req.LastCommitInfo.GetVotes()
+
+	res.Events = append(res.Events, abci.Event{
+		Type: "inj_meta",
+	})
 
 	// call the hooks with the BeginBlock messages
 	for _, streamingListener := range app.abciListeners {


### PR DESCRIPTION
# Context

- We upgraded to cosmos 47 and use cometbft for indexer. When we query events from release-prod >< cometbft, it results in base64-encoded string for event attributes, so eventprovider api can't parse it properly
For root cause, see this PR: https://github.com/InjectiveLabs/injective-indexer/pull/662 (it fails in some cases)

- We don't have a proper method to detect version at specific block height

# Goal

We need to add a mechanism to detect which version of event block is at seamlessly, so we know how to parse it properly + to not make breaking changes to block results in eventprovider

# Approaches

1. Cometbft back to use []byte
- Simple change and nothing is broken.
- Cons: We introduce one more repo to maintain and using []byte in proto is heavier than string (golang will use base64 encoding when json marshal and respond to the client)

2. Add new event in event list to detect event version
- Pros: fast, reliable, take advantage for new improvement in cometbft, doesn't cost more query from indexer; we can even add more fields in the future to get block metadata

- Cons: More event per block, but it's only 7 bytes, more 35GB per next 500M blocks (in 10 years), we can use the event to attach further information in terms of event version
Same idea from https://github.com/InjectiveLabs/injective-indexer/pull/626

I will go with 2 

Event changes:

release-prod (cosmos 45):
We don't have additional inj_meta event (response is in base-64 encoded string, longer compare to cosmos 47)

<img width="771" alt="image" src="https://user-images.githubusercontent.com/30641530/236987485-8206a223-f7dc-435a-b839-873b2c54fe8f.png">

Same for original `cosmos 47`, but cosmos 47 response size is shorter

<img width="618" alt="image" src="https://user-images.githubusercontent.com/30641530/236989626-6bd71fbc-8da9-4500-9fd0-7ce6cc74015d.png">

Now, with this update:

There is an empty `inj_meta` event since we don't have any special metadata for now, just this event for recognizing the version

<img width="438" alt="image" src="https://user-images.githubusercontent.com/30641530/236986796-4e7c667a-a48f-4d24-9bd4-3d7f9c044c43.png">

