### PR TITLE
feat: fix authz error issue

### DIFF
--- a/x/auth/vesting/types/msgs.go
+++ b/x/auth/vesting/types/msgs.go
@@ -182,6 +182,14 @@ func (msg MsgCreatePeriodicVestingAccount) ValidateBasic() error {
 	}
 
 	for i, period := range msg.VestingPeriods {
+		if !period.Amount.IsValid() {
+			return sdkerrors.ErrInvalidCoins.Wrap(period.Amount.String())
+		}
+
+		if !period.Amount.IsAllPositive() {
+			return sdkerrors.ErrInvalidCoins.Wrap(period.Amount.String())
+		}
+
 		if period.Length < 1 {
 			return fmt.Errorf("invalid period length of %d in period %d, length must be greater than 0", period.Length, i)
 		}

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"time"
@@ -101,7 +102,7 @@ func (k Keeper) DispatchActions(ctx sdk.Context, grantee sdk.AccAddress, msgs []
 
 			grant, found := k.getGrant(ctx, skey)
 			if !found {
-				return nil, sdkerrors.Wrapf(authz.ErrNoAuthorizationFound, "failed to update grant with key %s", string(skey))
+				return nil, sdkerrors.Wrapf(authz.ErrNoAuthorizationFound, "failed to update grant with key %s", base64.StdEncoding.EncodeToString(skey))
 			}
 
 			if grant.Expiration != nil && grant.Expiration.Before(now) {


### PR DESCRIPTION
When authz return grant not found error 

```
"failed to update grant with key %s", string(skey)
```
It attach the key which is not UTF-8 valid, grpc framework panics

It's easier and meaningful to fix this compare to fixing google grpc framework atm. This affects rawLog which is not part of consensus, so doesn't require chain upgrade
