### PR TITLE
fix: fix chainstreamer block message packing

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -757,7 +757,7 @@ func (app *BaseApp) beginBlock(_ *abci.RequestFinalizeBlock) (sdk.BeginBlock, er
 			)
 		}
 
-		app.AddStreamEvents(ctx.BlockHeight(), ctx.BlockTime(), resp.Events, true)
+		app.AddStreamEvents(ctx.BlockHeight(), ctx.BlockTime(), resp.Events, false)
 
 		resp.Events = sdk.MarkEventsToIndex(resp.Events, app.indexEvents)
 	}


### PR DESCRIPTION
This PR fixes chainstreamer message finalizing.
Flush true need to be sent only at the end of endBlock handler in order to avoid to mix events from differents blocks.

Context: sending flush true as parameter at AddStreamEvents call will cause chain stream event publisher to finalize current block message and forward it to the connected clients