### PR TITLE
chore: update cometbft version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
-	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v0.38.11-inj-4
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v0.38.11-inj-5
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cometbft v0.38.11-inj-4 h1:WBL3gGcPEYscqpIH+r1IkytmMhoLt247JtO71AlZ/iQ=
-github.com/InjectiveLabs/cometbft v0.38.11-inj-4/go.mod h1:WreBJKC7CtZ9cNsb5p6uNpfCBwNWDu+risVb58GTLfY=
+github.com/InjectiveLabs/cometbft v0.38.11-inj-5 h1:HHqZv2OY3LqHdDj5IxdMgun2Tp3je9EeDk9IET+eoUk=
+github.com/InjectiveLabs/cometbft v0.38.11-inj-5/go.mod h1:WreBJKC7CtZ9cNsb5p6uNpfCBwNWDu+risVb58GTLfY=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20240522173845-46ef88f66790 h1:F4FYZR9rLg9igzxitFdLU5s7ZU9XS0wUB7DbkBOVXc8=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20240522173845-46ef88f66790/go.mod h1:ZW4eIE98wivInyQyhxU2nHqEielc/iZAcr41qNyWSrw=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=


### PR DESCRIPTION
Update tag of cometbft dependency to `v0.38.11-inj-5`, which includes a bug fix concerning the `FinalizeBlockRequest` 