### PR TITLE
fix: set correct header.AppHash field in internalFinalizeBlock

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -723,7 +723,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Request
 		Time:               req.Time,
 		ProposerAddress:    req.ProposerAddress,
 		NextValidatorsHash: req.NextValidatorsHash,
-		AppHash:            req.AppHash,
+		AppHash:            app.LastCommitID().Hash,
 		ValidatorsHash:     req.ValidatorsHash,
 		ConsensusHash:      req.ConsensusHash,
 		DataHash:           req.DataHash,


### PR DESCRIPTION
This PR reverts a change we made in setting the `AppHash` of header in `internalFinalizedBlock`.

This invalid value was causing the tests in `injective-core/injective-chain/modules/oracle` to fail - something related to IBC.

