### PR TITLE
refactor!: bump Comet to version with Mempool lanes and DOG  2 (supersedes #43)

### DIFF
--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -185,5 +185,5 @@ require (
 // Use local Cosmos SDK to use ABCI message types in CometBFT v1.
 replace github.com/cosmos/cosmos-sdk => ../../.
 
-// Import the store module from the v0.50.x-inj-comet-v1 branch
+// Import the store module from the v0.50.x-store-comet1-inj branch
 replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -185,4 +185,5 @@ require (
 // Use local Cosmos SDK to use ABCI message types in CometBFT v1.
 replace github.com/cosmos/cosmos-sdk => ../../.
 
-replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
+// Import the store module from the v0.50.x-inj-comet-v1 branch
+replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e

--- a/client/v2/go.sum
+++ b/client/v2/go.sum
@@ -47,8 +47,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/go.mod
+++ b/go.mod
@@ -191,21 +191,21 @@ require (
 	nhooyr.io/websocket v1.8.6 // indirect
 )
 
-// )
 replace cosmossdk.io/api => ./api
 
 // Below are the long-lived replace of the Cosmos SDK
 replace (
-	cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
-	// TODO(sainoe) => figure out if the three imports above are needed
+	// Import the store module from the v0.50.x-inj-comet-v1 branch
+	cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 	cosmossdk.io/x/evidence => ./x/evidence
 	cosmossdk.io/x/feegrant => ./x/feegrant
 	cosmossdk.io/x/upgrade => ./x/upgrade
 
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ replace cosmossdk.io/api => ./api
 
 // Below are the long-lived replace of the Cosmos SDK
 replace (
-	// Import the store module from the v0.50.x-inj-comet-v1 branch
+	// Import the store module from the v0.50.x-store-comet1-inj branch
 	cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 	cosmossdk.io/x/evidence => ./x/evidence
 	cosmossdk.io/x/feegrant => ./x/feegrant

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -448,10 +448,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -267,6 +267,7 @@ replace (
 )
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -728,10 +728,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/store/go.mod
+++ b/store/go.mod
@@ -76,6 +76,7 @@ require (
 )
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/store/go.sum
+++ b/store/go.sum
@@ -133,10 +133,10 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -264,6 +264,7 @@ replace (
 )
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -725,10 +725,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/x/circuit/go.mod
+++ b/x/circuit/go.mod
@@ -196,7 +196,7 @@ replace (
 	cosmossdk.io/x/staking => ../staking
 )
 
-// Import the store module from the v0.50.x-inj-comet-v1 branch
+// Import the store module from the v0.50.x-store-comet1-inj branch
 replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (

--- a/x/circuit/go.mod
+++ b/x/circuit/go.mod
@@ -196,10 +196,11 @@ replace (
 	cosmossdk.io/x/staking => ../staking
 )
 
-// Use store v1.1.0 bumped to CometBFT v1
-replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
+// Import the store module from the v0.50.x-inj-comet-v1 branch
+replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/circuit/go.sum
+++ b/x/circuit/go.sum
@@ -45,8 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -453,10 +453,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/x/evidence/go.mod
+++ b/x/evidence/go.mod
@@ -197,7 +197,7 @@ replace (
 	cosmossdk.io/x/staking => ../staking
 )
 
-// Import the store module from the v0.50.x-inj-comet-v1 branch
+// Import the store module from the v0.50.x-store-comet1-inj branch
 replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (

--- a/x/evidence/go.mod
+++ b/x/evidence/go.mod
@@ -197,10 +197,11 @@ replace (
 	cosmossdk.io/x/staking => ../staking
 )
 
-// Use store v1.1.0 bumped to CometBFT v1
-replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
+// Import the store module from the v0.50.x-inj-comet-v1 branch
+replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/evidence/go.sum
+++ b/x/evidence/go.sum
@@ -45,8 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -453,10 +453,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/x/feegrant/go.mod
+++ b/x/feegrant/go.mod
@@ -194,10 +194,11 @@ replace (
 	cosmossdk.io/depinject => ../../depinject
 )
 
-// Use store v1.1.0 bumped to CometBFT v1
-replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
+// Import the store module from the v0.50.x-inj-comet-v1 branch
+replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/feegrant/go.mod
+++ b/x/feegrant/go.mod
@@ -194,7 +194,7 @@ replace (
 	cosmossdk.io/depinject => ../../depinject
 )
 
-// Import the store module from the v0.50.x-inj-comet-v1 branch
+// Import the store module from the v0.50.x-store-comet1-inj branch
 replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (

--- a/x/feegrant/go.sum
+++ b/x/feegrant/go.sum
@@ -45,8 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -457,10 +457,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/x/nft/go.mod
+++ b/x/nft/go.mod
@@ -188,10 +188,11 @@ replace github.com/cosmos/cosmos-sdk => ../../.
 
 replace cosmossdk.io/api => ../../api
 
-// Use store v1.1.0 bumped to CometBFT v1
-replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
+// Import the store module from the v0.50.x-inj-comet-v1 branch
+replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/nft/go.mod
+++ b/x/nft/go.mod
@@ -188,7 +188,7 @@ replace github.com/cosmos/cosmos-sdk => ../../.
 
 replace cosmossdk.io/api => ../../api
 
-// Import the store module from the v0.50.x-inj-comet-v1 branch
+// Import the store module from the v0.50.x-store-comet1-inj branch
 replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (

--- a/x/nft/go.sum
+++ b/x/nft/go.sum
@@ -49,8 +49,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -447,10 +447,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/x/upgrade/go.mod
+++ b/x/upgrade/go.mod
@@ -225,10 +225,11 @@ replace (
 	cosmossdk.io/x/staking => ../staking
 )
 
-// Use store v1.1.0 bumped to CometBFT v1
-replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39
+// Import the store module from the v0.50.x-inj-comet-v1 branch
+replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52
-	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52
+	// Use CometBFT v1.0.1 with Mempool lanes and DOG
+	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/upgrade/go.mod
+++ b/x/upgrade/go.mod
@@ -225,7 +225,7 @@ replace (
 	cosmossdk.io/x/staking => ../staking
 )
 
-// Import the store module from the v0.50.x-inj-comet-v1 branch
+// Import the store module from the v0.50.x-store-comet1-inj branch
 replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e
 
 replace (

--- a/x/upgrade/go.sum
+++ b/x/upgrade/go.sum
@@ -227,8 +227,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39 h1:gc4NplJGLVhGYEZgzbUyE41yf2h9qjoj6wk5a0PZD9g=
-github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250303163942-1853f781be39/go.mod h1:ke75BnB0gpzLOvlDD+EW0a/douBhtl04oWXdmNJlZTk=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
+github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -727,10 +727,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52 h1:Cq0FXghrX7s8UTFyB6gH+SdNPiGwS+9+TustZ4OKhUw=
-github.com/injectivelabs/cometbft v1.0.2-0.20250306060709-658f4c10ac52/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52 h1:l44Mrd6kVwMVdNtaub0tX9tV6tNTjljoPbXYoxXihqk=
-github.com/injectivelabs/cometbft/api v1.0.1-0.20250306060709-658f4c10ac52/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
+github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
+github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
* Bump Comet version to use [v1.x-inj](https://github.com/InjectiveLabs/cometbft/tree/v1.x-inj) branch.
* Bump Store version to use [v0.50.x-store-comet1-inj](https://github.com/InjectiveLabs/cosmos-sdk/tree/v0.50.x-store-comet1-inj) branch.

Supersedes #43.
