### PR TITLE
chore(deps): update cometbft to v1.0.1-inj exact tag.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
@@ -448,8 +450,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -268,6 +268,6 @@ replace (
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -227,6 +227,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -728,8 +730,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/store/go.mod
+++ b/store/go.mod
@@ -77,6 +77,6 @@ require (
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/store/go.sum
+++ b/store/go.sum
@@ -7,6 +7,8 @@ cosmossdk.io/math v1.3.0/go.mod h1:vnRTxewy+M7BtXBNFybkuhSH4WfedVAAnERHgVFhp3k=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -133,8 +135,6 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -265,6 +265,6 @@ replace (
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -225,6 +225,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
 github.com/InjectiveLabs/metrics v0.0.10/go.mod h1:eYu++0DVUjk/jjV9WgvCo8gQU+16Yoyhp1iu+ghKNME=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -725,8 +727,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/x/circuit/go.mod
+++ b/x/circuit/go.mod
@@ -201,6 +201,6 @@ replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/circuit/go.sum
+++ b/x/circuit/go.sum
@@ -45,6 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
@@ -453,8 +455,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/x/evidence/go.mod
+++ b/x/evidence/go.mod
@@ -202,6 +202,6 @@ replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/evidence/go.sum
+++ b/x/evidence/go.sum
@@ -45,6 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
@@ -453,8 +455,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/x/feegrant/go.mod
+++ b/x/feegrant/go.mod
@@ -199,6 +199,6 @@ replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/feegrant/go.sum
+++ b/x/feegrant/go.sum
@@ -45,6 +45,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
@@ -457,8 +459,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/x/nft/go.mod
+++ b/x/nft/go.mod
@@ -193,6 +193,6 @@ replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/nft/go.sum
+++ b/x/nft/go.sum
@@ -49,6 +49,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
@@ -447,8 +449,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/x/upgrade/go.mod
+++ b/x/upgrade/go.mod
@@ -230,6 +230,6 @@ replace cosmossdk.io/store => github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0
 
 replace (
 	// Use CometBFT v1.0.1 with Mempool lanes and DOG
-	github.com/cometbft/cometbft => github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9
+	github.com/cometbft/cometbft => github.com/InjectiveLabs/cometbft v1.0.1-inj
 	github.com/cometbft/cometbft/api => github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9
 )

--- a/x/upgrade/go.sum
+++ b/x/upgrade/go.sum
@@ -227,6 +227,8 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/InjectiveLabs/cometbft v1.0.1-inj h1:RWOknL0elsUNrYSk8tJ1UKCe0CCeOMQ80u25hucvpIs=
+github.com/InjectiveLabs/cometbft v1.0.1-inj/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e h1:nzS8WlAX58G7N/+1RTVPnJejYOT8ny+c/8f7OelxPSc=
 github.com/InjectiveLabs/cosmos-sdk/store v1.1.1-0.20250317140226-272ef0ccbb2e/go.mod h1:f4Bw+bUoyCodFz56ngJ/FDWiTdpJxWuDAr7tq7vAxuo=
 github.com/InjectiveLabs/metrics v0.0.10 h1:BoOwXnCtRRIPmq06jcI20pXZYE758eusaCI5jDOoN4U=
@@ -727,8 +729,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9 h1:dv7XInpkZdVnj8ogSzYHNdqlkAseuyTN/mP6FIXmMm0=
-github.com/injectivelabs/cometbft v1.0.2-0.20250315062455-e9e4c8a0ecb9/go.mod h1:RgHHndb7wdtm9etmVj4tDn1NynC9YKIEJW9UUI3FCn4=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9 h1:CF4i7hDq39uQaRDBChTiYfGSFGz3KxH5EhJbG9zsOOI=
 github.com/injectivelabs/cometbft/api v1.0.1-0.20250315062455-e9e4c8a0ecb9/go.mod h1:Ivh6nSCTJPQOyfQo8dgnyu/T88it092sEqSrZSmTQN8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=


### PR DESCRIPTION
Imports release tag https://github.com/InjectiveLabs/cometbft/releases/tag/v1.0.1-inj

Also, fix InjectiveLabs case in the import file.
