### PR TITLE
fix: missing x/tx/signing patch for EVM support

### DIFF
--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -301,6 +301,11 @@ func (c *Context) makeGetSignersFunc(descriptor protoreflect.MessageDescriptor) 
 				}
 				return arr, nil
 			}
+		case protoreflect.BytesKind:
+			fieldGetters[i] = func(msg proto.Message, arr [][]byte) ([][]byte, error) {
+				addrBz := msg.ProtoReflect().Get(field).Bytes()
+				return append(arr, addrBz), nil
+			}
 		default:
 			return nil, fmt.Errorf("unexpected field type %s for field %s in message %s", field.Kind(), fieldName, descriptor.FullName())
 		}


### PR DESCRIPTION
Missed in https://github.com/InjectiveLabs/cosmos-sdk/pull/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extracting signer addresses represented as raw bytes in protobuf messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->