### PR TITLE
[CP-379] backport sdk patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 * (baseapp) [#21979](https://github.com/cosmos/cosmos-sdk/pull/21979) Create CheckTxHandler to allow extending the logic of CheckTx.
+* (baseapp) [#24074](https://github.com/cosmos/cosmos-sdk/pull/24074) Use CometBFT's ComputeProtoSizeForTxs in defaultTxSelector.SelectTxForProposal for consistency.
 
 ## [v0.50.13](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.13) - 2025-03-12
 

--- a/baseapp/abci_utils.go
+++ b/baseapp/abci_utils.go
@@ -11,6 +11,7 @@ import (
 	cmtprotocrypto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
+	cmttypes "github.com/cometbft/cometbft/types"
 	protoio "github.com/cosmos/gogoproto/io"
 	"github.com/cosmos/gogoproto/proto" //nolint: gci // ignore this line for this linter
 
@@ -488,7 +489,7 @@ func (ts *defaultTxSelector) Clear() {
 }
 
 func (ts *defaultTxSelector) SelectTxForProposal(_ context.Context, maxTxBytes, maxBlockGas uint64, memTx sdk.Tx, txBz []byte) bool {
-	txSize := uint64(len(txBz))
+	txSize := uint64(cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{txBz}))
 
 	var txGasLimit uint64
 	if memTx != nil {

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -493,6 +493,9 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_NoOpMempoolTxSelection()
 	s.Require().NoError(err)
 	s.Require().Len(txBz, 152)
 
+	txDataSize := int(cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{txBz}))
+	s.Require().Equal(txDataSize, 155)
+
 	testCases := map[string]struct {
 		ctx         sdk.Context
 		req         *abci.PrepareProposalRequest
@@ -514,7 +517,7 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_NoOpMempoolTxSelection()
 			}),
 			req: &abci.PrepareProposalRequest{
 				Txs:        [][]byte{txBz, txBz, txBz, txBz, txBz},
-				MaxTxBytes: 456,
+				MaxTxBytes: 465,
 			},
 			expectedTxs: 0,
 		},
@@ -522,9 +525,17 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_NoOpMempoolTxSelection()
 			ctx: s.ctx,
 			req: &abci.PrepareProposalRequest{
 				Txs:        [][]byte{txBz, txBz, txBz, txBz, txBz},
-				MaxTxBytes: 456,
+				MaxTxBytes: 465,
 			},
 			expectedTxs: 3,
+		},
+		"large max tx bytes len calculation": {
+			ctx: s.ctx,
+			req: &abci.RequestPrepareProposal{
+				Txs:        [][]byte{txBz, txBz, txBz, txBz, txBz},
+				MaxTxBytes: 456,
+			},
+			expectedTxs: 2,
 		},
 		"max gas and tx bytes": {
 			ctx: s.ctx.WithConsensusParams(cmtproto.ConsensusParams{
@@ -534,7 +545,7 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_NoOpMempoolTxSelection()
 			}),
 			req: &abci.PrepareProposalRequest{
 				Txs:        [][]byte{txBz, txBz, txBz, txBz, txBz},
-				MaxTxBytes: 456,
+				MaxTxBytes: 465,
 			},
 			expectedTxs: 2,
 		},
@@ -543,7 +554,7 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_NoOpMempoolTxSelection()
 	for name, tc := range testCases {
 		s.Run(name, func() {
 			// iterate multiple times to ensure the tx selector is cleared each time
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 6; i++ {
 				resp, err := handler(tc.ctx, tc.req)
 				s.Require().NoError(err)
 				s.Require().Len(resp.Txs, tc.expectedTxs)

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -531,7 +531,7 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_NoOpMempoolTxSelection()
 		},
 		"large max tx bytes len calculation": {
 			ctx: s.ctx,
-			req: &abci.RequestPrepareProposal{
+			req: &abci.PrepareProposalRequest{
 				Txs:        [][]byte{txBz, txBz, txBz, txBz, txBz},
 				MaxTxBytes: 456,
 			},

--- a/x/tx/internal/testpb/signers.proto
+++ b/x/tx/internal/testpb/signers.proto
@@ -92,7 +92,7 @@ message DeeplyNestedRepeatedSigner {
 
 message BadSigner {
   option (cosmos.msg.v1.signer) = "signer";
-  bytes signer                  = 1;
+  float signer                  = 1;
 }
 
 message NoSignerOption {

--- a/x/tx/internal/testpb/signers.pulsar.go
+++ b/x/tx/internal/testpb/signers.pulsar.go
@@ -3,6 +3,7 @@ package testpb
 
 import (
 	_ "cosmossdk.io/api/cosmos/msg/v1"
+	binary "encoding/binary"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
 	runtime "github.com/cosmos/cosmos-proto/runtime"
@@ -10,6 +11,7 @@ import (
 	protoiface "google.golang.org/protobuf/runtime/protoiface"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
+	math "math"
 	reflect "reflect"
 	sync "sync"
 )
@@ -7900,8 +7902,8 @@ func (x *fastReflection_BadSigner) Interface() protoreflect.ProtoMessage {
 // While iterating, mutating operations may only be performed
 // on the current field descriptor.
 func (x *fastReflection_BadSigner) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
-	if len(x.Signer) != 0 {
-		value := protoreflect.ValueOfBytes(x.Signer)
+	if x.Signer != float32(0) || math.Signbit(float64(x.Signer)) {
+		value := protoreflect.ValueOfFloat32(x.Signer)
 		if !f(fd_BadSigner_signer, value) {
 			return
 		}
@@ -7922,7 +7924,7 @@ func (x *fastReflection_BadSigner) Range(f func(protoreflect.FieldDescriptor, pr
 func (x *fastReflection_BadSigner) Has(fd protoreflect.FieldDescriptor) bool {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		return len(x.Signer) != 0
+		return x.Signer != float32(0) || math.Signbit(float64(x.Signer))
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -7940,7 +7942,7 @@ func (x *fastReflection_BadSigner) Has(fd protoreflect.FieldDescriptor) bool {
 func (x *fastReflection_BadSigner) Clear(fd protoreflect.FieldDescriptor) {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		x.Signer = nil
+		x.Signer = float32(0)
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -7959,7 +7961,7 @@ func (x *fastReflection_BadSigner) Get(descriptor protoreflect.FieldDescriptor) 
 	switch descriptor.FullName() {
 	case "BadSigner.signer":
 		value := x.Signer
-		return protoreflect.ValueOfBytes(value)
+		return protoreflect.ValueOfFloat32(value)
 	default:
 		if descriptor.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -7981,7 +7983,7 @@ func (x *fastReflection_BadSigner) Get(descriptor protoreflect.FieldDescriptor) 
 func (x *fastReflection_BadSigner) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		x.Signer = value.Bytes()
+		x.Signer = float32(value.Float())
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -8018,7 +8020,7 @@ func (x *fastReflection_BadSigner) Mutable(fd protoreflect.FieldDescriptor) prot
 func (x *fastReflection_BadSigner) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		return protoreflect.ValueOfBytes(nil)
+		return protoreflect.ValueOfFloat32(float32(0))
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -8088,9 +8090,8 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 		var n int
 		var l int
 		_ = l
-		l = len(x.Signer)
-		if l > 0 {
-			n += 1 + l + runtime.Sov(uint64(l))
+		if x.Signer != 0 || math.Signbit(float64(x.Signer)) {
+			n += 5
 		}
 		if x.unknownFields != nil {
 			n += len(x.unknownFields)
@@ -8121,12 +8122,11 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 			i -= len(x.unknownFields)
 			copy(dAtA[i:], x.unknownFields)
 		}
-		if len(x.Signer) > 0 {
-			i -= len(x.Signer)
-			copy(dAtA[i:], x.Signer)
-			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Signer)))
+		if x.Signer != 0 || math.Signbit(float64(x.Signer)) {
+			i -= 4
+			binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(x.Signer))))
 			i--
-			dAtA[i] = 0xa
+			dAtA[i] = 0xd
 		}
 		if input.Buf != nil {
 			input.Buf = append(input.Buf, dAtA...)
@@ -8178,39 +8178,16 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 			}
 			switch fieldNum {
 			case 1:
-				if wireType != 2 {
+				if wireType != 5 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Signer", wireType)
 				}
-				var byteLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					byteLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if byteLen < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				postIndex := iNdEx + byteLen
-				if postIndex < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				if postIndex > l {
+				var v uint32
+				if (iNdEx + 4) > l {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
 				}
-				x.Signer = append(x.Signer[:0], dAtA[iNdEx:postIndex]...)
-				if x.Signer == nil {
-					x.Signer = []byte{}
-				}
-				iNdEx = postIndex
+				v = uint32(binary.LittleEndian.Uint32(dAtA[iNdEx:]))
+				iNdEx += 4
+				x.Signer = float32(math.Float32frombits(v))
 			default:
 				iNdEx = preIndex
 				skippy, err := runtime.Skip(dAtA[iNdEx:])
@@ -9386,7 +9363,7 @@ type BadSigner struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Signer []byte `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
+	Signer float32 `protobuf:"fixed32,1,opt,name=signer,proto3" json:"signer,omitempty"`
 }
 
 func (x *BadSigner) Reset() {
@@ -9409,11 +9386,11 @@ func (*BadSigner) Descriptor() ([]byte, []int) {
 	return file_signers_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *BadSigner) GetSigner() []byte {
+func (x *BadSigner) GetSigner() float32 {
 	if x != nil {
 		return x.Signer
 	}
-	return nil
+	return 0
 }
 
 type NoSignerOption struct {
@@ -9885,7 +9862,7 @@ var file_signers_proto_rawDesc = []byte{
 	0x05, 0x69, 0x6e, 0x6e, 0x65, 0x72, 0x3a, 0x0a, 0x82, 0xe7, 0xb0, 0x2a, 0x05, 0x69, 0x6e, 0x6e,
 	0x65, 0x72, 0x3a, 0x0a, 0x82, 0xe7, 0xb0, 0x2a, 0x05, 0x69, 0x6e, 0x6e, 0x65, 0x72, 0x22, 0x30,
 	0x0a, 0x09, 0x42, 0x61, 0x64, 0x53, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x12, 0x16, 0x0a, 0x06, 0x73,
-	0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x06, 0x73, 0x69, 0x67,
+	0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x02, 0x52, 0x06, 0x73, 0x69, 0x67,
 	0x6e, 0x65, 0x72, 0x3a, 0x0b, 0x82, 0xe7, 0xb0, 0x2a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72,
 	0x22, 0x28, 0x0a, 0x0e, 0x4e, 0x6f, 0x53, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x4f, 0x70, 0x74, 0x69,
 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01,


### PR DESCRIPTION
Cherry pick and backport https://github.com/cosmos/cosmos-sdk/pull/24074

See https://github.com/cosmos/cosmos-sdk/pull/18551 for rationale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved consistency in transaction size calculation for proposal selection, ensuring accurate inclusion checks.
- **Tests**
	- Updated and expanded tests to reflect changes in transaction size computation and proposal handling.
- **Documentation**
	- Added a changelog entry describing the update to transaction size computation.
- **Refactor**
	- Changed the type of the signer field in test protocol buffers from bytes to float for the BadSigner message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->