### PR TITLE
[CP-390] deposit validator rewards pool restricted for non-staking token

### DIFF
--- a/baseapp/testutil/mock/mocks.go
+++ b/baseapp/testutil/mock/mocks.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	crypto  "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
+	v1 "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
 	types "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -37,10 +37,10 @@ func (m *MockValidatorStore) EXPECT() *MockValidatorStoreMockRecorder {
 }
 
 // GetPubKeyByConsAddr mocks base method.
-func (m *MockValidatorStore) GetPubKeyByConsAddr(arg0 context.Context, arg1 types.ConsAddress) (crypto.PublicKey, error) {
+func (m *MockValidatorStore) GetPubKeyByConsAddr(arg0 context.Context, arg1 types.ConsAddress) (v1.PublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPubKeyByConsAddr", arg0, arg1)
-	ret0, _ := ret[0].(crypto.PublicKey)
+	ret0, _ := ret[0].(v1.PublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/tests/integration/distribution/keeper/msg_server_test.go
+++ b/tests/integration/distribution/keeper/msg_server_test.go
@@ -942,12 +942,14 @@ func TestMsgDepositValidatorRewardsPool(t *testing.T) {
 			},
 		},
 		{
-			name: "happy path (non-staking token)",
+			name: "invalid coins (non-staking token)",
 			msg: &distrtypes.MsgDepositValidatorRewardsPool{
 				Depositor:        addr.String(),
 				ValidatorAddress: valAddr1.String(),
 				Amount:           amt,
 			},
+			expErr:    true,
+			expErrMsg: "invalid coins",
 		},
 		{
 			name: "invalid validator",

--- a/x/distribution/keeper/msg_server.go
+++ b/x/distribution/keeper/msg_server.go
@@ -174,6 +174,17 @@ func (k msgServer) DepositValidatorRewardsPool(ctx context.Context, msg *types.M
 		return nil, err
 	}
 
+	bondDenom, err := k.stakingKeeper.BondDenom(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get bond denom")
+	}
+
+	for _, coin := range msg.Amount {
+		if coin.Denom != bondDenom {
+			return nil, errors.Wrapf(sdkerrors.ErrInvalidCoins, "not a bond token denom: %s", coin.Denom)
+		}
+	}
+
 	// deposit coins from depositor's account to the distribution module
 	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, depositor, types.ModuleName, msg.Amount); err != nil {
 		return nil, err

--- a/x/distribution/testutil/expected_keepers_mocks.go
+++ b/x/distribution/testutil/expected_keepers_mocks.go
@@ -235,6 +235,21 @@ func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
 	return m.recorder
 }
 
+// BondDenom mocks base method.
+func (m *MockStakingKeeper) BondDenom(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BondDenom", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BondDenom indicates an expected call of BondDenom.
+func (mr *MockStakingKeeperMockRecorder) BondDenom(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BondDenom", reflect.TypeOf((*MockStakingKeeper)(nil).BondDenom), ctx)
+}
+
 // ConsensusAddressCodec mocks base method.
 func (m *MockStakingKeeper) ConsensusAddressCodec() address.Codec {
 	m.ctrl.T.Helper()

--- a/x/distribution/types/expected_keepers.go
+++ b/x/distribution/types/expected_keepers.go
@@ -53,6 +53,8 @@ type StakingKeeper interface {
 	GetAllSDKDelegations(ctx context.Context) ([]stakingtypes.Delegation, error)
 	GetAllValidators(ctx context.Context) ([]stakingtypes.Validator, error)
 	GetAllDelegatorDelegations(ctx context.Context, delegator sdk.AccAddress) ([]stakingtypes.Delegation, error)
+
+	BondDenom(ctx context.Context) (string, error)
 }
 
 // StakingHooks event hooks for staking validator object (noalias)

--- a/x/staking/testutil/expected_keepers_mocks.go
+++ b/x/staking/testutil/expected_keepers_mocks.go
@@ -10,7 +10,7 @@ import (
 
 	address "cosmossdk.io/core/address"
 	math "cosmossdk.io/math"
-	crypto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
+	v1 "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
 	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gomock "github.com/golang/mock/gomock"
@@ -307,10 +307,10 @@ func (mr *MockValidatorSetMockRecorder) Delegation(arg0, arg1, arg2 interface{})
 }
 
 // GetPubKeyByConsAddr mocks base method.
-func (m *MockValidatorSet) GetPubKeyByConsAddr(arg0 context.Context, arg1 types.ConsAddress) (crypto.PublicKey, error) {
+func (m *MockValidatorSet) GetPubKeyByConsAddr(arg0 context.Context, arg1 types.ConsAddress) (v1.PublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPubKeyByConsAddr", arg0, arg1)
-	ret0, _ := ret[0].(crypto.PublicKey)
+	ret0, _ := ret[0].(v1.PublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure only the correct staking token can be used when depositing to the validator rewards pool.
- **Bug Fixes**
  - Updated test cases to expect errors when invalid (non-staking) tokens are used for deposits.
- **Tests**
  - Enhanced test coverage to verify error handling for invalid coin denominations.
- **Chores**
  - Updated and extended mock interfaces to support new staking token validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->