### PR TITLE
[CP-405] add accessor all registered errors

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -81,6 +81,27 @@ func ABCIError(codespace string, code uint32, log string) error {
 	return Wrap(&Error{codespace: codespace, code: code, desc: "unknown"}, log)
 }
 
+// AllRegisteredErrors returns a deep copy of all registered errors.
+// The returned map contains error IDs as keys (formatted as "codespace:code")
+// and their corresponding Error instances as values.
+//
+// This function returns a deep copy to prevent external modification of the
+// original error registry, ensuring the integrity of registered errors.
+func AllRegisteredErrors() map[string]*Error {
+	// Create a deep copy to prevent external modification of registered errors
+	copy := make(map[string]*Error, len(usedCodes))
+	for key, err := range usedCodes {
+		// Create a new Error instance with the same values
+		copy[key] = &Error{
+			codespace: err.codespace,
+			code:      err.code,
+			desc:      err.desc,
+			grpcCode:  err.grpcCode,
+		}
+	}
+	return copy
+}
+
 // Error represents a root error.
 //
 // Weave framework is using root error to categorize issues. Each instance


### PR DESCRIPTION
- Added logic to access all registered errors, to aid in the automation of errors documentation generation

Solves [CP-405](https://injective-labs.atlassian.net/browse/CP-405)


[CP-405]: https://injective-labs.atlassian.net/browse/CP-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve a copy of all registered errors for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->