### PR TITLE
fix Testnetify (devnetify) for genesis problem with incorrect type for `initial_height`

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -991,7 +991,7 @@ func Testnetify(ctx *Context, testnetAppCreator types.AppCreator, db dbm.DB, tra
 	}
 
 	// Since we modified the chainID, we set the new genesisDoc in the stateDB.
-	b, err := cmtjson.Marshal(genDoc)
+	b, err := cmtjson.MarshalIndent(genDoc, "", "  ")
 	if err != nil {
 		return nil, err
 	}

--- a/server/start.go
+++ b/server/start.go
@@ -784,6 +784,14 @@ func Testnetify(ctx *Context, testnetAppCreator types.AppCreator, db dbm.DB, tra
 	if err := appGen.SaveAs(genFilePath); err != nil {
 		return nil, err
 	}
+	// remove hash from StateDB since it will not match to genesis hash anymore
+	stateDB, err := cmtcfg.DefaultDBProvider(&cmtcfg.DBContext{ID: "state", Config: config})
+	if err != nil {
+		return nil, err
+	}
+	if err := stateDB.DeleteSync([]byte("genesisDocHash")); err != nil {
+		return nil, err
+	}
 
 	// Regenerate addrbook.json to prevent peers on old network from causing error logs.
 	addrBookPath := filepath.Join(config.RootDir, "config", "addrbook.json")
@@ -805,11 +813,6 @@ func Testnetify(ctx *Context, testnetAppCreator types.AppCreator, db dbm.DB, tra
 		return nil, err
 	}
 	blockStore := store.NewBlockStore(blockStoreDB)
-
-	stateDB, err := cmtcfg.DefaultDBProvider(&cmtcfg.DBContext{ID: "state", Config: config})
-	if err != nil {
-		return nil, err
-	}
 
 	defer blockStore.Close()
 	defer stateDB.Close()

--- a/x/genutil/types/genesis.go
+++ b/x/genutil/types/genesis.go
@@ -80,7 +80,7 @@ func (ag *AppGenesis) ValidateAndComplete() error {
 
 // SaveAs is a utility method for saving AppGenesis as a JSON file.
 func (ag *AppGenesis) SaveAs(file string) error {
-	appGenesisBytes, err := json.MarshalIndent(ag, "", "  ")
+	appGenesisBytes, err := cmtjson.MarshalIndent(ag, "", " ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents genesis hash mismatches after regenerating a testnet, improving node startup reliability.
  - Consolidates state database access to avoid duplicate openings and related inconsistencies.

- Improvements
  - Genesis files are now saved with consistent, indented formatting for better readability.
  - Ensures the latest formatted genesis is persisted in both file and state storage for consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->