### PR TITLE
docs: fix links so that they render in mintlify (downstream docs)

### DIFF
--- a/x/evidence/README.md
+++ b/x/evidence/README.md
@@ -248,7 +248,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/x/evidence/keeper/infracti
 
 **Note:** The slashing, jailing, and tombstoning calls are delegated through the `x/slashing` module
 that emits informative events and finally delegates calls to the `x/staking` module. See documentation
-on slashing and jailing in [State Transitions](../staking/README.md#state-transitions).
+on slashing and jailing in [State Transitions](./staking/#state-transitions).
 
 ## Client
 

--- a/x/feegrant/README.md
+++ b/x/feegrant/README.md
@@ -124,7 +124,7 @@ Example cmd:
 
 ### Granted Fee Deductions
 
-Fees are deducted from grants in the `x/auth` ante handler. To learn more about how ante handlers work, read the [Auth Module AnteHandlers Guide](../auth/README.md#antehandlers).
+Fees are deducted from grants in the `x/auth` ante handler. To learn more about how ante handlers work, read the [Auth Module AnteHandlers Guide](./auth/#antehandlers).
 
 ### Gas
 

--- a/x/gov/README.md
+++ b/x/gov/README.md
@@ -2491,7 +2491,7 @@ The gov module has two locations for metadata where users can provide further co
 
 ### Proposal
 
-Location: off-chain as json object stored on IPFS (mirrors [group proposal](../group/README.md#metadata))
+Location: off-chain as json object stored on IPFS (mirrors [group proposal](./group/#metadata))
 
 ```json
 {
@@ -2511,7 +2511,7 @@ In v0.46, the `authors` field is a comma-separated string. Frontends are encoura
 
 ### Vote
 
-Location: on-chain as json within 255 character limit (mirrors [group vote](../group/README.md#metadata))
+Location: on-chain as json within 255 character limit (mirrors [group vote](./group/#metadata))
 
 ```json
 {

--- a/x/group/README.md
+++ b/x/group/README.md
@@ -2113,7 +2113,7 @@ The group module has four locations for metadata where users can provide further
 
 ### Proposal
 
-Location: off-chain as json object stored on IPFS (mirrors [gov proposal](../gov/README.md#metadata))
+Location: off-chain as json object stored on IPFS (mirrors [gov proposal](./gov/#metadata))
 
 ```json
 {
@@ -2133,7 +2133,7 @@ In v0.46, the `authors` field is a comma-separated string. Frontends are encoura
 
 ### Vote
 
-Location: on-chain as json within 255 character limit (mirrors [gov vote](../gov/README.md#metadata))
+Location: on-chain as json within 255 character limit (mirrors [gov vote](./gov/#metadata))
 
 ```json
 {

--- a/x/slashing/README.md
+++ b/x/slashing/README.md
@@ -106,7 +106,7 @@ long as it contains precommits from +2/3 of total voting power.
 
 Proposers are incentivized to include precommits from all validators in the CometBFT `LastCommitInfo`
 by receiving additional fees proportional to the difference between the voting
-power included in the `LastCommitInfo` and +2/3 (see [fee distribution](../distribution/README.md#begin-block)).
+power included in the `LastCommitInfo` and +2/3 (see [fee distribution](./distribution/#begin-block)).
 
 ```go
 type LastCommitInfo struct {


### PR DESCRIPTION
# Description

- spec files in markdown are copied from this repo into the main docs repo
- update the links so that they aren't broken when rendered in the docs repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation cross-reference links to improve navigation consistency across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->