### PR TITLE
[CP-773] fix: inter-block cache data race

### DIFF
--- a/store/cache/cache_test.go
+++ b/store/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache_test
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	dbm "github.com/cosmos/cosmos-db"
@@ -15,6 +17,8 @@ import (
 	"cosmossdk.io/store/types"
 	"cosmossdk.io/store/wrapper"
 )
+
+// Note: cachekv is still imported for TestCacheWrap which tests CacheWrap() returns *cachekv.Store
 
 func TestGetOrSetStoreCache(t *testing.T) {
 	db := wrapper.NewDBWrapper(dbm.NewMemDB())
@@ -98,4 +102,102 @@ func TestCacheWrap(t *testing.T) {
 
 	cacheWrapper := mngr.GetStoreCache(sKey, store).CacheWrap()
 	require.IsType(t, &cachekv.Store{}, cacheWrapper)
+}
+
+// TestInterBlockCacheRaceConcurrent reproduces a race condition in CommitKVStoreCache
+// where a concurrent gRPC query can re-populate the cache with a stale value after
+// Delete() removes it from cache but before the underlying store deletion completes.
+//
+// This is the root cause of app hash divergence on sentry nodes in Cosmos SDK chains.
+// Sentry nodes handle heavy gRPC query traffic during block processing, making them
+// susceptible to this race condition.
+//
+// Store hierarchy:
+//
+//	CacheKVStore (per-block) -> CommitKVStoreCache (inter-block) -> IAVL
+//
+// The bug is in CommitKVStoreCache.Delete() which performs two non-atomic operations:
+//
+//	func (ckv *CommitKVStoreCache) Delete(key []byte) {
+//	    ckv.cache.Remove(key)           // Step 1: Remove from LRU cache
+//	    ckv.CommitKVStore.Delete(key)   // Step 2: Delete from underlying store
+//	}
+//
+// Race condition - a concurrent Get() can slip between steps 1 and 2:
+//
+//	1. Delete: cache.Remove(key)           <- Cache now empty for this key
+//	2. Get:    cache.Get(key) -> miss      <- Concurrent query sees cache miss
+//	3. Get:    CommitKVStore.Get(key)      <- Returns OLD value (delete not yet applied!)
+//	4. Delete: CommitKVStore.Delete(key)   <- Now deleted from underlying store
+//	5. Get:    cache.Add(key, stale_value) <- BUG: Stale value added AFTER delete!
+//
+// Result: Cache has stale value, IAVL has nil. Next block reads stale value from cache,
+// computes wrong state transitions (e.g., double-distributing fees), and diverges from
+// validators who didn't hit the race.
+func TestInterBlockCacheRaceConcurrent(t *testing.T) {
+	db := wrapper.NewDBWrapper(dbm.NewMemDB())
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+
+	sKey := types.NewKVStoreKey("bank")
+	tree := iavl.NewMutableTree(db, 100, false, log.NewNopLogger())
+	store := iavlstore.UnsafeNewStore(tree)
+
+	interBlockCache := mngr.GetStoreCache(sKey, store)
+
+	feeCollectorKey := []byte("fee_collector_balance")
+	initialBalance := []byte("100")
+
+	raceDetected := atomic.Bool{}
+
+	// Run many iterations to catch the race
+	for i := 0; i < 1000; i++ {
+		// Reset state: set value and commit
+		interBlockCache.Set(feeCollectorKey, initialBalance)
+		_, _, err := tree.SaveVersion()
+		require.NoError(t, err)
+
+		require.Equal(t, initialBalance, interBlockCache.Get(feeCollectorKey))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Goroutine 1: Delete (simulates block processing)
+		go func() {
+			defer wg.Done()
+			interBlockCache.Delete(feeCollectorKey)
+		}()
+
+		// Goroutine 2: Get (simulates concurrent query)
+		go func() {
+			defer wg.Done()
+			_ = interBlockCache.Get(feeCollectorKey)
+		}()
+
+		wg.Wait()
+
+		// Commit the deletion
+		_, _, err = tree.SaveVersion()
+		require.NoError(t, err)
+
+		// IAVL should have nil
+		require.Nil(t, store.Get(feeCollectorKey), "IAVL should have nil")
+
+		// Check if cache has stale value (the bug)
+		cachedValue := interBlockCache.Get(feeCollectorKey)
+		if cachedValue != nil {
+			raceDetected.Store(true)
+			t.Logf("RACE DETECTED at iteration %d: cache has stale value '%s'", i, string(cachedValue))
+			t.Logf("IAVL correctly has nil, but cache returned stale data")
+			t.Logf("This causes app hash divergence on sentry nodes!")
+			break
+		}
+	}
+
+	if raceDetected.Load() {
+		t.Log("BUG CONFIRMED: Inter-block cache race condition exists")
+		t.Log("Fix: Make Delete() atomic or track pending deletions")
+		t.FailNow()
+	} else {
+		t.Log("Race not triggered in 1000 iterations (may need more runs or -race flag)")
+	}
 }


### PR DESCRIPTION
Fixes race condition in CommitKVStoreCache that causes app hash divergence on nodes with concurrent gRPC query traffic during block processing.

The Bug:  CommitKVStoreCache.Delete() performs two non-atomic operations:

```
func (ckv *CommitKVStoreCache) Delete(key []byte) {
      ckv.cache.Remove(string(key))      // Step 1: Remove from LRU cache
      ckv.CommitKVStore.Delete(key)      // Step 2: Delete from underlying store
}

```
A concurrent Get() can interleave between these steps:

1. Delete: cache.Remove(key)           ← Cache now empty for this key
2. Get:    cache.Get(key) → miss       ← Concurrent query sees cache miss
3. Get:    CommitKVStore.Get(key)      ← Returns OLD value (delete not applied yet!)
4. Delete: CommitKVStore.Delete(key)   ← Underlying store now has deletion
5. Get:    cache.Add(key, stale_value) ← BUG: Stale value added AFTER delete!

Result: The cache contains a stale value while the underlying IAVL tree correctly has nil. Subsequent reads hit the cache and return the stale value, causing incorrect state transitions.

Impact: This can lead to app hash mismatches with the following pattern:

  - Block N-2: fee_collector balance = 100
  - Block N-1: fee_collector balance distributed and deleted (set to 0/nil)
  - Block N: fee_collector read returns stale value (100) from corrupted cache

This caused distribution.AllocateTokens() to double-distribute fees, resulting in different state than validators and consensus failure.

Unit Test

  `TestInterBlockCacheRaceConcurrent` reproduces the race condition by running concurrent Delete() and Get() operations in a loop:

```
  for i := 0; i < 1000; i++ {
      // Setup: set value and commit
      interBlockCache.Set(feeCollectorKey, initialBalance)
      tree.SaveVersion()

      var wg sync.WaitGroup
      wg.Add(2)

      // Goroutine 1: Delete (simulates block processing)
      go func() {
          defer wg.Done()
          interBlockCache.Delete(feeCollectorKey)
      }()

      // Goroutine 2: Get (simulates concurrent gRPC query)
      go func() {
          defer wg.Done()
          _ = interBlockCache.Get(feeCollectorKey)
      }()

      wg.Wait()
      tree.SaveVersion()

      // IAVL correctly has nil
      require.Nil(t, store.Get(feeCollectorKey))

      // BUG: Cache may have stale value!
      if interBlockCache.Get(feeCollectorKey) != nil {
          t.Fatal("RACE DETECTED: cache has stale value, IAVL has nil")
      }
  }

```
Before fix: Test fails intermittently with "RACE DETECTED" — the cache returns a stale value while IAVL correctly has nil.
After fix: Test passes — cache correctly returns nil for deleted keys.

The Fix

Two changes to make cache operations thread-safe:

1. Use nil sentinel instead of removing from cache

Instead of cache.Remove(key) which creates a hole that triggers IAVL reads, Delete() now stores nil as a sentinel value. This ensures any
concurrent or subsequent Get() returns nil rather than fetching a potentially stale value from the underlying store.

2. Add sync.RWMutex with double-check locking

Protects against the race where Get() could add a stale value after Delete() has marked the key as deleted. The double-check pattern in Get() ensures that if Delete() runs while Get() is waiting for the write lock, Get() will see the nil sentinel.

```
func (ckv *CommitKVStoreCache) Delete(key []byte) {
    ckv.mtx.Lock()
    ckv.cache.Add(keyStr, nil)  // Mark as deleted (not Remove!)
    ckv.mtx.Unlock()

    ckv.CommitKVStore.Delete(key)
}

func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
    // Fast path: read lock
    ckv.mtx.RLock()
    valueI, ok := ckv.cache.Get(keyStr)
    ckv.mtx.RUnlock()

    if ok {
        if valueI == nil { return nil }  // Deleted
        return valueI.([]byte)
    }

    // Slow path: write lock with double-check
    ckv.mtx.Lock()
    defer ckv.mtx.Unlock()

    // Re-check - Delete() may have run while we waited
    valueI, ok = ckv.cache.Get(keyStr)
    if ok {
        if valueI == nil { return nil }
        return valueI.([]byte)
    }

    value := ckv.CommitKVStore.Get(key)
    ckv.cache.Add(keyStr, value)
    return value
}
```

  Performance Considerations

  - Cache hits (common case): Only a read lock is acquired — minimal overhead
  - Cache misses: Write lock with double-check — slightly more overhead but prevents corruption
  - No additional memory: Uses nil as sentinel within existing cache structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition in cache operations by adding thread-safety mechanisms to prevent data corruption during concurrent access.

* **Tests**
  * Added concurrency test to verify cache behavior under simultaneous operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->